### PR TITLE
Add missing header for non-debug builds

### DIFF
--- a/include/CL/sycl/detail/debug.hpp
+++ b/include/CL/sycl/detail/debug.hpp
@@ -13,8 +13,9 @@
     License. See LICENSE.TXT for details.
 */
 
-#ifdef TRISYCL_DEBUG
 #include <iostream>
+
+#ifdef TRISYCL_DEBUG
 #include <sstream>
 #include <string>
 #include <thread>


### PR DESCRIPTION
The display() method for SYCL's cl::sycl::detail::display_vector struct
uses std::cout, but the <iostream> header is only included for debugging
builds. This causes non-debug builds to break due to use of the
undefined reference:

```
$ cd triSYCL/tests; make
g++ -Wall -std=c++1y -I/home/chris/src/triSYCL/include -I/home/chris/src/triSYCL/tests/common -fopenmp    item/item.cpp   -o item/item
^[[A^[[A^[[A^[[A^[[A^[[A^[[A^[[BIn file included from /home/chris/src/triSYCL/include/CL/sycl/accessor/detail/accessor.hpp:17:0,
                 from /home/chris/src/triSYCL/include/CL/sycl/accessor.hpp:15,
                 from /home/chris/src/triSYCL/include/CL/sycl.hpp:40,
                 from item/item.cpp:15:
/home/chris/src/triSYCL/include/CL/sycl/detail/debug.hpp: In member function ‘void cl::sycl::detail::display_vector<T>::display() const’:
/home/chris/src/triSYCL/include/CL/sycl/detail/debug.hpp:110:7: error: ‘cout’ is not a member of ‘std’
       std::cout << " " << e;
       ^
/home/chris/src/triSYCL/include/CL/sycl/detail/debug.hpp:111:5: error: ‘cout’ is not a member of ‘std’
     std::cout << std::endl;
     ^
<builtin>: recipe for target 'item/item' failed
make: *** [item/item] Error 1
```

This patch removes the TRISYCL_DEBUG conditional guard
around the inclusion of the iostream header.