### PR TITLE
Add "inline" qualifier to non-template functions

### DIFF
--- a/include/CL/sycl/detail/unimplemented.hpp
+++ b/include/CL/sycl/detail/unimplemented.hpp
@@ -22,7 +22,7 @@ namespace detail {
 
     Can be changed to call assert(0) or whatever.
 */
-void unimplemented() {
+inline void unimplemented() {
   std::cerr << "Error: using a non implemented feature!!!" << std::endl
             << "Please contribute to the open source implementation. :-)"
             << std::endl;

--- a/include/CL/sycl/id.hpp
+++ b/include/CL/sycl/id.hpp
@@ -63,9 +63,9 @@ public:
 
     Cannot use a template on the number of dimensions because the implicit
     conversion would not be tried. */
-auto make_id(id<1> i) { return i; }
-auto make_id(id<2> i) { return i; }
-auto make_id(id<3> i) { return i; }
+inline auto make_id(id<1> i) { return i; }
+inline auto make_id(id<2> i) { return i; }
+inline auto make_id(id<3> i) { return i; }
 
 
 /** Construct an id<> from a function call with arguments, like

--- a/include/CL/sycl/range.hpp
+++ b/include/CL/sycl/range.hpp
@@ -45,9 +45,9 @@ public:
     Cannot use a template on the number of dimensions because the implicit
     conversion would not be tried.
 */
-auto make_range(range<1> r) { return r; }
-auto make_range(range<2> r) { return r; }
-auto make_range(range<3> r) { return r; }
+inline auto make_range(range<1> r) { return r; }
+inline auto make_range(range<2> r) { return r; }
+inline auto make_range(range<3> r) { return r; }
 
 
 /** Construct a range<> from a function call with arguments, like


### PR DESCRIPTION
Currently you get "multiple definition" errors if the SYCL headers are included in more than one compilation unit.  This just adds "inline" qualifiers to the functions so that they can link correctly.