### PR TITLE
Fix initialisation order of members in one of the buffer constructors

### DIFF
--- a/include/CL/sycl/buffer/detail/buffer.hpp
+++ b/include/CL/sycl/buffer/detail/buffer.hpp
@@ -70,8 +70,8 @@ struct buffer : public detail::debug<buffer<T, Dimensions>>,
       without further allocation */
   buffer(const T * host_data, range<Dimensions> r) :
     /// \todo Need to solve this const buffer issue in a clean way
-    access { const_cast<T *>(host_data), r },
-    buffer_base { true }
+    buffer_base { true },
+    access { const_cast<T *>(host_data), r }
     {}
 
 


### PR DESCRIPTION
This just switches the initialisation order of two of the buffer members in the constructor that takes a pointer and size.  This stops a "{foo} will be initialized after {bar}" warning which on some build systems is elevated to an error (not the internal makefiles).

Note this is already covered by a test, except that in the test it's just a warning:

    In file included from triSYCL/include/CL/sycl/buffer.hpp:19:0,
                     from triSYCL/include/CL/sycl.hpp:42,
                     from buffer/read_write_buffer.cpp:7:
    triSYCL/include/CL/sycl/buffer/detail/buffer.hpp: In instantiation of 'cl::sycl::detail::buffer<T, Dimensions>::buffer(const T*, cl::sycl::range<Dimensions>) [with T = double; long unsigned int Dimensions = 2ul]':
    triSYCL/include/CL/sycl/buffer.hpp:95:75:   required from 'cl::sycl::buffer<T, Dimensions, Allocator>::buffer(const T*, cl::sycl::range<Dimensions>, Allocator) [with T = double; long unsigned int Dimensions = 2ul; Allocator = std::allocator<double>]'
        buffer/read_write_buffer.cpp:32:64:   required from here
    triSYCL/include/CL/sycl/buffer/detail/buffer.hpp:52:41: warning: 'cl::sycl::detail::buffer<double, 2ul>::access' will be initialized after [-Wreorder]
       boost::multi_array_ref<T, Dimensions> access;
                                             ^
    triSYCL/include/CL/sycl/buffer/detail/buffer.hpp:74:24: warning:   base 'cl::sycl::detail::buffer_base' [-Wreorder]
         buffer_base { true }
                            ^
    triSYCL/include/CL/sycl/buffer/detail/buffer.hpp:71:3: warning:   when initialized here [-Wreorder]
       buffer(const T * host_data, range<Dimensions> r) :
       ^
