### PR TITLE
Add accessor::get_size()

### DIFF
--- a/include/CL/sycl/buffer/detail/accessor.hpp
+++ b/include/CL/sycl/buffer/detail/accessor.hpp
@@ -131,6 +131,12 @@ struct accessor : public detail::debug<accessor<T,
   }
 
 
+  /// Returns the size of the underlying buffer in number of elements.
+  std::size_t get_size() const {
+    return array.num_elements();
+  }
+
+
   /** Use the accessor with integers à la [][][]
 
       Use array_view_type::reference instead of auto& because it does not


### PR DESCRIPTION
cf. [SYCL 1.2 specification](https://www.khronos.org/registry/sycl/specs/sycl-1.2.pdf), 3.4.6.3 Accessor class, pp. 79.

Would make live easier for me to have this available :-)